### PR TITLE
Added OpenAL extensions EFX and EAX plus presets from kcat repository

### DIFF
--- a/source/bindbc/openal/binddynamic.d
+++ b/source/bindbc/openal/binddynamic.d
@@ -108,6 +108,44 @@ extern(C) @nogc nothrow {
     alias palcCaptureStart = void function(ALCdevice*);
     alias palcCaptureStop = void function(ALCdevice*);
     alias palcCaptureSamples = void function(ALCdevice*, ALCvoid*, ALCsizei);
+
+    //EFX Functions
+    alias palGenEffects = void function(ALsizei n, ALuint *effects);
+    alias palDeleteEffects = void function(ALsizei n, const ALuint *effects);
+    alias palIsEffect = ALboolean function(ALuint effect);
+    alias palEffecti = void function(ALuint effect, ALenum param, ALint iValue);
+    alias palEffectiv = void function(ALuint effect, ALenum param, const (ALint)* piValues);
+    alias palEffectf = void function(ALuint effect, ALenum param, ALfloat flValue);
+    alias palEffectfv = void function(ALuint effect, ALenum param, const (ALfloat)* pflValues);
+    alias palGetEffecti = void function(ALuint effect, ALenum param, ALint *piValue);
+    alias palGetEffectiv = void function(ALuint effect, ALenum param, ALint *piValues);
+    alias palGetEffectf = void function(ALuint effect, ALenum param, ALfloat *pflValue);
+    alias palGetEffectfv = void function(ALuint effect, ALenum param, ALfloat *pflValues);
+
+    alias palGenFilters = void function(ALsizei n, ALuint *filters);
+    alias palDeleteFilters = void function(ALsizei n, const ALuint *filters);
+    alias palIsFilter = ALboolean function(ALuint filter);
+    alias palFilteri = void function(ALuint filter, ALenum param, ALint iValue);
+    alias palFilteriv = void function(ALuint filter, ALenum param, const ALint *piValues);
+    alias palFilterf = void function(ALuint filter, ALenum param, ALfloat flValue);
+    alias palFilterfv = void function(ALuint filter, ALenum param, const ALfloat *pflValues);
+    alias palGetFilteri = void function(ALuint filter, ALenum param, ALint *piValue);
+    alias palGetFilteriv = void function(ALuint filter, ALenum param, ALint *piValues);
+    alias palGetFilterf = void function(ALuint filter, ALenum param, ALfloat *pflValue);
+    alias palGetFilterfv = void function(ALuint filter, ALenum param, ALfloat *pflValues);
+
+    alias palGenAuxiliaryEffectSlots = void function(ALsizei n, ALuint *effectslots);
+    alias palDeleteAuxiliaryEffectSlots = void function(ALsizei n, const ALuint *effectslots);
+    alias palIsAuxiliaryEffectSlot = ALboolean function(ALuint effectslot);
+    alias palAuxiliaryEffectSloti = void function(ALuint effectslot, ALenum param, ALint iValue);
+    alias palAuxiliaryEffectSlotiv = void function(ALuint effectslot, ALenum param, const ALint *piValues);
+    alias palAuxiliaryEffectSlotf = void function(ALuint effectslot, ALenum param, ALfloat flValue);
+    alias palAuxiliaryEffectSlotfv = void function(ALuint effectslot, ALenum param, const ALfloat *pflValues);
+    alias palGetAuxiliaryEffectSloti = void function(ALuint effectslot, ALenum param, ALint *piValue);
+    alias palGetAuxiliaryEffectSlotiv = void function(ALuint effectslot, ALenum param, ALint *piValues);
+    alias palGetAuxiliaryEffectSlotf = void function(ALuint effectslot, ALenum param, ALfloat *pflValue);
+    alias palGetAuxiliaryEffectSlotfv = void function(ALuint effectslot, ALenum param, ALfloat *pflValues);
+
 }
 
 __gshared {
@@ -204,6 +242,41 @@ __gshared {
     palcCaptureStart alcCaptureStart;
     palcCaptureStop alcCaptureStop;
     palcCaptureSamples alcCaptureSamples;
+
+    //EFX Functions
+    palGenEffects alGenEffects;
+    palDeleteEffects alDeleteEffects;
+    palIsEffect alIsEffect;
+    palEffecti alEffecti;
+    palEffectiv alEffectiv;
+    palEffectf alEffectf;
+    palEffectfv alEffectfv;
+    palGetEffecti alGetEffecti;
+    palGetEffectiv alGetEffectiv;
+    palGetEffectf alGetEffectf;
+    palGetEffectfv alGetEffectfv;
+    palGenFilters alGenFilters;
+    palDeleteFilters alDeleteFilters;
+    palIsFilter alIsFilter;
+    palFilteri alFilteri;
+    palFilteriv alFilteriv;
+    palFilterf alFilterf;
+    palFilterfv alFilterfv;
+    palGetFilteri alGetFilteri;
+    palGetFilteriv alGetFilteriv;
+    palGetFilterf alGetFilterf;
+    palGetFilterfv alGetFilterfv;
+    palGenAuxiliaryEffectSlots alGenAuxiliaryEffectSlots;
+    palDeleteAuxiliaryEffectSlots alDeleteAuxiliaryEffectSlots;
+    palIsAuxiliaryEffectSlot alIsAuxiliaryEffectSlot;
+    palAuxiliaryEffectSloti alAuxiliaryEffectSloti;
+    palAuxiliaryEffectSlotiv alAuxiliaryEffectSlotiv;
+    palAuxiliaryEffectSlotf alAuxiliaryEffectSlotf;
+    palAuxiliaryEffectSlotfv alAuxiliaryEffectSlotfv;
+    palGetAuxiliaryEffectSloti alGetAuxiliaryEffectSloti;
+    palGetAuxiliaryEffectSlotiv alGetAuxiliaryEffectSlotiv;
+    palGetAuxiliaryEffectSlotf alGetAuxiliaryEffectSlotf;
+    palGetAuxiliaryEffectSlotfv alGetAuxiliaryEffectSlotfv;
 }
 
 private {
@@ -224,7 +297,7 @@ bool isOpenALLoaded() { return lib != invalidHandle; }
 ALSupport loadOpenAL()
 {
     version(Windows) {
-        const(char)[][2] libNames = ["OpenAL32.dll", "soft-oal.dll"];
+        const(char)[][3] libNames = ["OpenAL32.dll", "soft-oal.dll", "soft_oal.dll"];
     }
     else version(OSX) {
         const(char)[][3] libNames = [
@@ -352,6 +425,41 @@ ALSupport loadOpenAL(const(char)* libName)
     lib.bindSymbol(cast(void**)&alcCaptureStart, "alcCaptureStart");
     lib.bindSymbol(cast(void**)&alcCaptureStop, "alcCaptureStop");
     lib.bindSymbol(cast(void**)&alcCaptureSamples, "alcCaptureSamples");
+
+    //EFX Extension
+    lib.bindSymbol(cast(void**)&alGenEffects, "alGenEffects");
+    lib.bindSymbol(cast(void**)&alDeleteEffects, "alDeleteEffects");
+    lib.bindSymbol(cast(void**)&alIsEffect, "alIsEffect");
+    lib.bindSymbol(cast(void**)&alEffecti, "alEffecti");
+    lib.bindSymbol(cast(void**)&alEffectiv, "alEffectiv");
+    lib.bindSymbol(cast(void**)&alEffectf, "alEffectf");
+    lib.bindSymbol(cast(void**)&alEffectfv, "alEffectfv");
+    lib.bindSymbol(cast(void**)&alGetEffecti, "alGetEffecti");
+    lib.bindSymbol(cast(void**)&alGetEffectiv, "alGetEffectiv");
+    lib.bindSymbol(cast(void**)&alGetEffectf, "alGetEffectf");
+    lib.bindSymbol(cast(void**)&alGetEffectfv, "alGetEffectfv");
+    lib.bindSymbol(cast(void**)&alGenFilters, "alGenFilters");
+    lib.bindSymbol(cast(void**)&alDeleteFilters, "alDeleteFilters");
+    lib.bindSymbol(cast(void**)&alIsFilter, "alIsFilter");
+    lib.bindSymbol(cast(void**)&alFilteri, "alFilteri");
+    lib.bindSymbol(cast(void**)&alFilteriv, "alFilteriv");
+    lib.bindSymbol(cast(void**)&alFilterf, "alFilterf");
+    lib.bindSymbol(cast(void**)&alFilterfv, "alFilterfv");
+    lib.bindSymbol(cast(void**)&alGetFilteri, "alGetFilteri");
+    lib.bindSymbol(cast(void**)&alGetFilteriv, "alGetFilteriv");
+    lib.bindSymbol(cast(void**)&alGetFilterf, "alGetFilterf");
+    lib.bindSymbol(cast(void**)&alGetFilterfv, "alGetFilterfv");
+    lib.bindSymbol(cast(void**)&alGenAuxiliaryEffectSlots, "alGenAuxiliaryEffectSlots");
+    lib.bindSymbol(cast(void**)&alDeleteAuxiliaryEffectSlots, "alDeleteAuxiliaryEffectSlots");
+    lib.bindSymbol(cast(void**)&alIsAuxiliaryEffectSlot, "alIsAuxiliaryEffectSlot");
+    lib.bindSymbol(cast(void**)&alAuxiliaryEffectSloti, "alAuxiliaryEffectSloti");
+    lib.bindSymbol(cast(void**)&alAuxiliaryEffectSlotiv, "alAuxiliaryEffectSlotiv");
+    lib.bindSymbol(cast(void**)&alAuxiliaryEffectSlotf, "alAuxiliaryEffectSlotf");
+    lib.bindSymbol(cast(void**)&alAuxiliaryEffectSlotfv, "alAuxiliaryEffectSlotfv");
+    lib.bindSymbol(cast(void**)&alGetAuxiliaryEffectSloti, "alGetAuxiliaryEffectSloti");
+    lib.bindSymbol(cast(void**)&alGetAuxiliaryEffectSlotiv, "alGetAuxiliaryEffectSlotiv");
+    lib.bindSymbol(cast(void**)&alGetAuxiliaryEffectSlotf, "alGetAuxiliaryEffectSlotf");
+    lib.bindSymbol(cast(void**)&alGetAuxiliaryEffectSlotfv, "alGetAuxiliaryEffectSlotfv");
 
     if(errorCount() != errCount) loadedVersion = ALSupport.badLibrary;
     else loadedVersion = ALSupport.al11;

--- a/source/bindbc/openal/bindstatic.d
+++ b/source/bindbc/openal/bindstatic.d
@@ -103,4 +103,43 @@ extern(C) @nogc nothrow {
     void alcCaptureStart(ALCdevice*);
     void alcCaptureStop(ALCdevice*);
     void alcCaptureSamples(ALCdevice*, ALCvoid*, ALCsizei);
+
+
+    //EFX Functions
+    void alGenEffects(ALsizei n, ALuint *effects);
+    void alDeleteEffects(ALsizei n, const ALuint *effects);
+    ALboolean alIsEffect(ALuint effect);
+    void alEffecti(ALuint effect, ALenum param, ALint iValue);
+    void alEffectiv(ALuint effect, ALenum param, const ALint *piValues);
+    void alEffectf(ALuint effect, ALenum param, ALfloat flValue);
+    void alEffectfv(ALuint effect, ALenum param, const ALfloat *pflValues);
+    void alGetEffecti(ALuint effect, ALenum param, ALint *piValue);
+    void alGetEffectiv(ALuint effect, ALenum param, ALint *piValues);
+    void alGetEffectf(ALuint effect, ALenum param, ALfloat *pflValue);
+    void alGetEffectfv(ALuint effect, ALenum param, ALfloat *pflValues);
+
+    void alGenFilters(ALsizei n, ALuint *filters);
+    void alDeleteFilters(ALsizei n, const ALuint *filters);
+    ALboolean alIsFilter(ALuint filter);
+    void alFilteri(ALuint filter, ALenum param, ALint iValue);
+    void alFilteriv(ALuint filter, ALenum param, const ALint *piValues);
+    void alFilterf(ALuint filter, ALenum param, ALfloat flValue);
+    void alFilterfv(ALuint filter, ALenum param, const ALfloat *pflValues);
+    void alGetFilteri(ALuint filter, ALenum param, ALint *piValue);
+    void alGetFilteriv(ALuint filter, ALenum param, ALint *piValues);
+    void alGetFilterf(ALuint filter, ALenum param, ALfloat *pflValue);
+    void alGetFilterfv(ALuint filter, ALenum param, ALfloat *pflValues);
+
+    void alGenAuxiliaryEffectSlots(ALsizei n, ALuint *effectslots);
+    void alDeleteAuxiliaryEffectSlots(ALsizei n, const ALuint *effectslots);
+    ALboolean alIsAuxiliaryEffectSlot(ALuint effectslot);
+    void alAuxiliaryEffectSloti(ALuint effectslot, ALenum param, ALint iValue);
+    void alAuxiliaryEffectSlotiv(ALuint effectslot, ALenum param, const ALint *piValues);
+    void alAuxiliaryEffectSlotf(ALuint effectslot, ALenum param, ALfloat flValue);
+    void alAuxiliaryEffectSlotfv(ALuint effectslot, ALenum param, const ALfloat *pflValues);
+    void alGetAuxiliaryEffectSloti(ALuint effectslot, ALenum param, ALint *piValue);
+    void alGetAuxiliaryEffectSlotiv(ALuint effectslot, ALenum param, ALint *piValues);
+    void alGetAuxiliaryEffectSlotf(ALuint effectslot, ALenum param, ALfloat *pflValue);
+    void alGetAuxiliaryEffectSlotfv(ALuint effectslot, ALenum param, ALfloat *pflValues);
+
 }

--- a/source/bindbc/openal/efx.d
+++ b/source/bindbc/openal/efx.d
@@ -1,0 +1,728 @@
+module bindbc.openal.efx;
+import bindbc.openal.types;
+
+version = OpenAL_EFX;
+enum ALC_EXT_EFX_NAME        = "ALC_EXT_EFX";
+enum ALC_EFX_MAJOR_VERSION   = 0x20001;
+enum ALC_EFX_MINOR_VERSION   = 0x20002;
+enum ALC_MAX_AUXILIARY_SENDS = 0x20003;
+
+///Listener Properties
+enum AL_METERS_PER_UNIT      = 0x20004;
+
+///Source Properties
+enum AL_DIRECT_FILTER                     = 0x20005;
+enum AL_AUXILIARY_SEND_FILTER             = 0x20006;
+enum AL_AIR_ABSORPTION_FACTOR             = 0x20007;
+enum AL_ROOM_ROLLOFF_FACTOR               = 0x20008;
+enum AL_CONE_OUTER_GAINHF                 = 0x20009;
+enum AL_DIRECT_FILTER_GAINHF_AUTO         = 0x2000A;
+enum AL_AUXILIARY_SEND_FILTER_GAIN_AUTO   = 0x2000B;
+enum AL_AUXILIARY_SEND_FILTER_GAINHF_AUTO = 0x2000C;
+
+
+///Effect Properties
+
+///Reverb effect parameters
+enum : ALuint
+{
+    AL_REVERB_DENSITY                = 0x0001,
+    AL_REVERB_DIFFUSION              = 0x0002,
+    AL_REVERB_GAIN                   = 0x0003,
+    AL_REVERB_GAINHF                 = 0x0004,
+    AL_REVERB_DECAY_TIME             = 0x0005,
+    AL_REVERB_DECAY_HFRATIO          = 0x0006,
+    AL_REVERB_REFLECTIONS_GAIN       = 0x0007,
+    AL_REVERB_REFLECTIONS_DELAY      = 0x0008,
+    AL_REVERB_LATE_REVERB_GAIN       = 0x0009,
+    AL_REVERB_LATE_REVERB_DELAY      = 0x000A,
+    AL_REVERB_AIR_ABSORPTION_GAINHF  = 0x000B,
+    AL_REVERB_ROOM_ROLLOFF_FACTOR    = 0x000C,
+    AL_REVERB_DECAY_HFLIMIT          = 0x000D,
+}
+
+///EAX Reverb effect parameters
+enum : ALuint
+{
+    AL_EAXREVERB_DENSITY               = 0x0001,
+    AL_EAXREVERB_DIFFUSION             = 0x0002,
+    AL_EAXREVERB_GAIN                  = 0x0003,
+    AL_EAXREVERB_GAINHF                = 0x0004,
+    AL_EAXREVERB_GAINLF                = 0x0005,
+    AL_EAXREVERB_DECAY_TIME            = 0x0006,
+    AL_EAXREVERB_DECAY_HFRATIO         = 0x0007,
+    AL_EAXREVERB_DECAY_LFRATIO         = 0x0008,
+    AL_EAXREVERB_REFLECTIONS_GAIN      = 0x0009,
+    AL_EAXREVERB_REFLECTIONS_DELAY     = 0x000A,
+    AL_EAXREVERB_REFLECTIONS_PAN       = 0x000B,
+    AL_EAXREVERB_LATE_REVERB_GAIN      = 0x000C,
+    AL_EAXREVERB_LATE_REVERB_DELAY     = 0x000D,
+    AL_EAXREVERB_LATE_REVERB_PAN       = 0x000E,
+    AL_EAXREVERB_ECHO_TIME             = 0x000F,
+    AL_EAXREVERB_ECHO_DEPTH            = 0x0010,
+    AL_EAXREVERB_MODULATION_TIME       = 0x0011,
+    AL_EAXREVERB_MODULATION_DEPTH      = 0x0012,
+    AL_EAXREVERB_AIR_ABSORPTION_GAINHF = 0x0013,
+    AL_EAXREVERB_HFREFERENCE           = 0x0014,
+    AL_EAXREVERB_LFREFERENCE           = 0x0015,
+    AL_EAXREVERB_ROOM_ROLLOFF_FACTOR   = 0x0016,
+    AL_EAXREVERB_DECAY_HFLIMIT         = 0x0017
+}
+
+/* Chorus effect parameters */
+enum : ALuint
+{
+    AL_CHORUS_WAVEFORM =  0x0001,
+    AL_CHORUS_PHASE    =  0x0002,
+    AL_CHORUS_RATE     =  0x0003,
+    AL_CHORUS_DEPTH    =  0x0004,
+    AL_CHORUS_FEEDBACK =  0x0005,
+    AL_CHORUS_DELAY    =  0x0006
+}
+
+///Distortion effect parameters
+enum : ALuint
+{
+    AL_DISTORTION_EDGE                       = 0x0001,
+    AL_DISTORTION_GAIN                       = 0x0002,
+    AL_DISTORTION_LOWPASS_CUTOFF             = 0x0003,
+    AL_DISTORTION_EQCENTER                   = 0x0004,
+    AL_DISTORTION_EQBANDWIDTH                = 0x0005,
+}
+
+///Echo effect parameters
+enum : ALuint
+{
+    AL_ECHO_DELAY                            = 0x0001,
+    AL_ECHO_LRDELAY                          = 0x0002,
+    AL_ECHO_DAMPING                          = 0x0003,
+    AL_ECHO_FEEDBACK                         = 0x0004,
+    AL_ECHO_SPREAD                           = 0x0005
+}
+
+/* Flanger effect parameters */
+enum : ALuint
+{
+    AL_FLANGER_WAVEFORM                      = 0x0001,
+    AL_FLANGER_PHASE                         = 0x0002,
+    AL_FLANGER_RATE                          = 0x0003,
+    AL_FLANGER_DEPTH                         = 0x0004,
+    AL_FLANGER_FEEDBACK                      = 0x0005,
+    AL_FLANGER_DELAY                         = 0x0006
+}
+    
+
+/* Frequency shifter effect parameters */
+enum : ALuint
+{
+    AL_FREQUENCY_SHIFTER_FREQUENCY           = 0x0001,
+    AL_FREQUENCY_SHIFTER_LEFT_DIRECTION      = 0x0002,
+    AL_FREQUENCY_SHIFTER_RIGHT_DIRECTION     = 0x0003
+}
+
+/* Vocal morpher effect parameters */
+
+enum : ALuint
+{
+    AL_VOCAL_MORPHER_PHONEMEA                = 0x0001,
+    AL_VOCAL_MORPHER_PHONEMEA_COARSE_TUNING  = 0x0002,
+    AL_VOCAL_MORPHER_PHONEMEB                = 0x0003,
+    AL_VOCAL_MORPHER_PHONEMEB_COARSE_TUNING  = 0x0004,
+    AL_VOCAL_MORPHER_WAVEFORM                = 0x0005,
+    AL_VOCAL_MORPHER_RATE                    = 0x0006
+}
+
+/* Pitchshifter effect parameters */
+
+enum : ALuint
+{
+    AL_PITCH_SHIFTER_COARSE_TUNE             = 0x0001,
+    AL_PITCH_SHIFTER_FINE_TUNE               = 0x0002
+}
+
+/* Ringmodulator effect parameters */
+enum : ALuint
+{
+    AL_RING_MODULATOR_FREQUENCY              = 0x0001,
+    AL_RING_MODULATOR_HIGHPASS_CUTOFF        = 0x0002,
+    AL_RING_MODULATOR_WAVEFORM               = 0x0003
+}
+
+/* Autowah effect parameters */
+enum : ALuint
+{
+    AL_AUTOWAH_ATTACK_TIME                   = 0x0001,
+    AL_AUTOWAH_RELEASE_TIME                  = 0x0002,
+    AL_AUTOWAH_RESONANCE                     = 0x0003,
+    AL_AUTOWAH_PEAK_GAIN                     = 0x0004
+}
+
+/* Compressor effect parameters */
+enum : ALuint
+{
+    AL_COMPRESSOR_ONOFF                      = 0x0001
+}
+
+/* Equalizer effect parameters */
+enum : ALuint
+{
+    AL_EQUALIZER_LOW_GAIN                    = 0x0001,
+    AL_EQUALIZER_LOW_CUTOFF                  = 0x0002,
+    AL_EQUALIZER_MID1_GAIN                   = 0x0003,
+    AL_EQUALIZER_MID1_CENTER                 = 0x0004,
+    AL_EQUALIZER_MID1_WIDTH                  = 0x0005,
+    AL_EQUALIZER_MID2_GAIN                   = 0x0006,
+    AL_EQUALIZER_MID2_CENTER                 = 0x0007,
+    AL_EQUALIZER_MID2_WIDTH                  = 0x0008,
+    AL_EQUALIZER_HIGH_GAIN                   = 0x0009,
+    AL_EQUALIZER_HIGH_CUTOFF                 = 0x000A
+}
+
+/* Effect type */
+enum AL_EFFECT_FIRST_PARAMETER  = 0x0000;
+enum AL_EFFECT_LAST_PARAMETER   = 0x8000;
+enum AL_EFFECT_TYPE             = 0x8001;
+
+/* Effect types, used with the AL_EFFECT_TYPE property */
+enum : ALuint
+{
+    AL_EFFECT_NULL                           = 0x0000,
+    AL_EFFECT_REVERB                         = 0x0001,
+    AL_EFFECT_CHORUS                         = 0x0002,
+    AL_EFFECT_DISTORTION                     = 0x0003,
+    AL_EFFECT_ECHO                           = 0x0004,
+    AL_EFFECT_FLANGER                        = 0x0005,
+    AL_EFFECT_FREQUENCY_SHIFTER              = 0x0006,
+    AL_EFFECT_VOCAL_MORPHER                  = 0x0007,
+    AL_EFFECT_PITCH_SHIFTER                  = 0x0008,
+    AL_EFFECT_RING_MODULATOR                 = 0x0009,
+    AL_EFFECT_AUTOWAH                        = 0x000A,
+    AL_EFFECT_COMPRESSOR                     = 0x000B,
+    AL_EFFECT_EQUALIZER                      = 0x000C,
+    AL_EFFECT_EAXREVERB                      = 0x8000
+}
+
+/* Auxiliary Effect Slot properties. */
+enum : ALuint
+{
+    AL_EFFECTSLOT_EFFECT                     = 0x0001,
+    AL_EFFECTSLOT_GAIN                       = 0x0002,
+    AL_EFFECTSLOT_AUXILIARY_SEND_AUTO        = 0x0003
+}
+
+/* NULL Auxiliary Slot ID to disable a source send. */
+enum AL_EFFECTSLOT_NULL                       = 0x0000;
+
+
+/* Filter properties. */
+
+/* Lowpass filter parameters */
+enum : ALuint
+{
+    AL_LOWPASS_GAIN                          = 0x0001,
+    AL_LOWPASS_GAINHF                        = 0x0002
+}
+
+/* Highpass filter parameters */
+enum : ALuint
+{
+    AL_HIGHPASS_GAIN                         = 0x0001,
+    AL_HIGHPASS_GAINLF                       = 0x0002
+}
+
+/* Bandpass filter parameters */
+enum : ALuint
+{
+    AL_BANDPASS_GAIN                         = 0x0001,
+    AL_BANDPASS_GAINLF                       = 0x0002,
+    AL_BANDPASS_GAINHF                       = 0x0003
+}
+
+/* Filter type */
+
+enum AL_FILTER_FIRST_PARAMETER                = 0x0000;
+enum AL_FILTER_LAST_PARAMETER                 = 0x8000;
+enum AL_FILTER_TYPE                           = 0x8001;
+
+/* Filter types, used with the AL_FILTER_TYPE property */
+enum : ALuint
+{
+    AL_FILTER_NULL                           = 0x0000,
+    AL_FILTER_LOWPASS                        = 0x0001,
+    AL_FILTER_HIGHPASS                       = 0x0002,
+    AL_FILTER_BANDPASS                       = 0x0003,
+}
+
+
+
+/* Lowpass filter */
+enum AL_LOWPASS_MIN_GAIN =                      (0.0f);
+enum AL_LOWPASS_MAX_GAIN =                      (1.0f);
+enum AL_LOWPASS_DEFAULT_GAIN =                  (1.0f);
+
+enum AL_LOWPASS_MIN_GAINHF =                    (0.0f);
+enum AL_LOWPASS_MAX_GAINHF =                    (1.0f);
+enum AL_LOWPASS_DEFAULT_GAINHF =                (1.0f);
+
+/* Highpass filter */
+enum AL_HIGHPASS_MIN_GAIN =                     (0.0f);
+enum AL_HIGHPASS_MAX_GAIN =                     (1.0f);
+enum AL_HIGHPASS_DEFAULT_GAIN =                 (1.0f);
+
+enum AL_HIGHPASS_MIN_GAINLF =                   (0.0f);
+enum AL_HIGHPASS_MAX_GAINLF =                   (1.0f);
+enum AL_HIGHPASS_DEFAULT_GAINLF =               (1.0f);
+
+/* Bandpass filter */
+enum AL_BANDPASS_MIN_GAIN =                     (0.0f);
+enum AL_BANDPASS_MAX_GAIN =                     (1.0f);
+enum AL_BANDPASS_DEFAULT_GAIN =                 (1.0f);
+
+enum AL_BANDPASS_MIN_GAINHF =                   (0.0f);
+enum AL_BANDPASS_MAX_GAINHF =                   (1.0f);
+enum AL_BANDPASS_DEFAULT_GAINHF =               (1.0f);
+
+enum AL_BANDPASS_MIN_GAINLF =                   (0.0f);
+enum AL_BANDPASS_MAX_GAINLF =                   (1.0f);
+enum AL_BANDPASS_DEFAULT_GAINLF =               (1.0f);
+
+
+/* Effect parameter ranges and defaults. */
+
+/* Standard reverb effect */
+enum AL_REVERB_MIN_DENSITY =                    (0.0f);
+enum AL_REVERB_MAX_DENSITY =                    (1.0f);
+enum AL_REVERB_DEFAULT_DENSITY =                (1.0f);
+
+enum AL_REVERB_MIN_DIFFUSION =                  (0.0f);
+enum AL_REVERB_MAX_DIFFUSION =                  (1.0f);
+enum AL_REVERB_DEFAULT_DIFFUSION =              (1.0f);
+
+enum AL_REVERB_MIN_GAIN =                       (0.0f);
+enum AL_REVERB_MAX_GAIN =                       (1.0f);
+enum AL_REVERB_DEFAULT_GAIN =                   (0.32f);
+
+enum AL_REVERB_MIN_GAINHF =                     (0.0f);
+enum AL_REVERB_MAX_GAINHF =                     (1.0f);
+enum AL_REVERB_DEFAULT_GAINHF =                 (0.89f);
+
+enum AL_REVERB_MIN_DECAY_TIME =                 (0.1f);
+enum AL_REVERB_MAX_DECAY_TIME =                 (20.0f);
+enum AL_REVERB_DEFAULT_DECAY_TIME =             (1.49f);
+
+enum AL_REVERB_MIN_DECAY_HFRATIO =              (0.1f);
+enum AL_REVERB_MAX_DECAY_HFRATIO =              (2.0f);
+enum AL_REVERB_DEFAULT_DECAY_HFRATIO =          (0.83f);
+
+enum AL_REVERB_MIN_REFLECTIONS_GAIN =           (0.0f);
+enum AL_REVERB_MAX_REFLECTIONS_GAIN =           (3.16f);
+enum AL_REVERB_DEFAULT_REFLECTIONS_GAIN =       (0.05f);
+
+enum AL_REVERB_MIN_REFLECTIONS_DELAY =          (0.0f);
+enum AL_REVERB_MAX_REFLECTIONS_DELAY =          (0.3f);
+enum AL_REVERB_DEFAULT_REFLECTIONS_DELAY =      (0.007f);
+
+enum AL_REVERB_MIN_LATE_REVERB_GAIN =           (0.0f);
+enum AL_REVERB_MAX_LATE_REVERB_GAIN =           (10.0f);
+enum AL_REVERB_DEFAULT_LATE_REVERB_GAIN =       (1.26f);
+
+enum AL_REVERB_MIN_LATE_REVERB_DELAY =          (0.0f);
+enum AL_REVERB_MAX_LATE_REVERB_DELAY =          (0.1f);
+enum AL_REVERB_DEFAULT_LATE_REVERB_DELAY =      (0.011f);
+
+enum AL_REVERB_MIN_AIR_ABSORPTION_GAINHF =      (0.892f);
+enum AL_REVERB_MAX_AIR_ABSORPTION_GAINHF =      (1.0f);
+enum AL_REVERB_DEFAULT_AIR_ABSORPTION_GAINHF =  (0.994f);
+
+enum AL_REVERB_MIN_ROOM_ROLLOFF_FACTOR =        (0.0f);
+enum AL_REVERB_MAX_ROOM_ROLLOFF_FACTOR =        (10.0f);
+enum AL_REVERB_DEFAULT_ROOM_ROLLOFF_FACTOR =    (0.0f);
+
+enum AL_REVERB_MIN_DECAY_HFLIMIT =              AL_FALSE;
+enum AL_REVERB_MAX_DECAY_HFLIMIT =              AL_TRUE;
+enum AL_REVERB_DEFAULT_DECAY_HFLIMIT =          AL_TRUE;
+
+/* EAX reverb effect */
+enum AL_EAXREVERB_MIN_DENSITY =                 (0.0f);
+enum AL_EAXREVERB_MAX_DENSITY =                 (1.0f);
+enum AL_EAXREVERB_DEFAULT_DENSITY =             (1.0f);
+
+enum AL_EAXREVERB_MIN_DIFFUSION =               (0.0f);
+enum AL_EAXREVERB_MAX_DIFFUSION =               (1.0f);
+enum AL_EAXREVERB_DEFAULT_DIFFUSION =           (1.0f);
+
+enum AL_EAXREVERB_MIN_GAIN =                    (0.0f);
+enum AL_EAXREVERB_MAX_GAIN =                    (1.0f);
+enum AL_EAXREVERB_DEFAULT_GAIN =                (0.32f);
+
+enum AL_EAXREVERB_MIN_GAINHF =                  (0.0f);
+enum AL_EAXREVERB_MAX_GAINHF =                  (1.0f);
+enum AL_EAXREVERB_DEFAULT_GAINHF =              (0.89f);
+
+enum AL_EAXREVERB_MIN_GAINLF =                  (0.0f);
+enum AL_EAXREVERB_MAX_GAINLF =                  (1.0f);
+enum AL_EAXREVERB_DEFAULT_GAINLF =              (1.0f);
+
+enum AL_EAXREVERB_MIN_DECAY_TIME =              (0.1f);
+enum AL_EAXREVERB_MAX_DECAY_TIME =              (20.0f);
+enum AL_EAXREVERB_DEFAULT_DECAY_TIME =          (1.49f);
+
+enum AL_EAXREVERB_MIN_DECAY_HFRATIO =           (0.1f);
+enum AL_EAXREVERB_MAX_DECAY_HFRATIO =           (2.0f);
+enum AL_EAXREVERB_DEFAULT_DECAY_HFRATIO =       (0.83f);
+
+enum AL_EAXREVERB_MIN_DECAY_LFRATIO =           (0.1f);
+enum AL_EAXREVERB_MAX_DECAY_LFRATIO =           (2.0f);
+enum AL_EAXREVERB_DEFAULT_DECAY_LFRATIO =       (1.0f);
+
+enum AL_EAXREVERB_MIN_REFLECTIONS_GAIN =        (0.0f);
+enum AL_EAXREVERB_MAX_REFLECTIONS_GAIN =        (3.16f);
+enum AL_EAXREVERB_DEFAULT_REFLECTIONS_GAIN =    (0.05f);
+
+enum AL_EAXREVERB_MIN_REFLECTIONS_DELAY =       (0.0f);
+enum AL_EAXREVERB_MAX_REFLECTIONS_DELAY =       (0.3f);
+enum AL_EAXREVERB_DEFAULT_REFLECTIONS_DELAY =   (0.007f);
+
+enum AL_EAXREVERB_DEFAULT_REFLECTIONS_PAN_XYZ = (0.0f);
+
+enum AL_EAXREVERB_MIN_LATE_REVERB_GAIN =        (0.0f);
+enum AL_EAXREVERB_MAX_LATE_REVERB_GAIN =        (10.0f);
+enum AL_EAXREVERB_DEFAULT_LATE_REVERB_GAIN =    (1.26f);
+
+enum AL_EAXREVERB_MIN_LATE_REVERB_DELAY =       (0.0f);
+enum AL_EAXREVERB_MAX_LATE_REVERB_DELAY =       (0.1f);
+enum AL_EAXREVERB_DEFAULT_LATE_REVERB_DELAY =   (0.011f);
+
+enum AL_EAXREVERB_DEFAULT_LATE_REVERB_PAN_XYZ = (0.0f);
+
+enum AL_EAXREVERB_MIN_ECHO_TIME =               (0.075f);
+enum AL_EAXREVERB_MAX_ECHO_TIME =               (0.25f);
+enum AL_EAXREVERB_DEFAULT_ECHO_TIME =           (0.25f);
+
+enum AL_EAXREVERB_MIN_ECHO_DEPTH =              (0.0f);
+enum AL_EAXREVERB_MAX_ECHO_DEPTH =              (1.0f);
+enum AL_EAXREVERB_DEFAULT_ECHO_DEPTH =          (0.0f);
+
+enum AL_EAXREVERB_MIN_MODULATION_TIME =         (0.04f);
+enum AL_EAXREVERB_MAX_MODULATION_TIME =         (4.0f);
+enum AL_EAXREVERB_DEFAULT_MODULATION_TIME =     (0.25f);
+
+enum AL_EAXREVERB_MIN_MODULATION_DEPTH =        (0.0f);
+enum AL_EAXREVERB_MAX_MODULATION_DEPTH =        (1.0f);
+enum AL_EAXREVERB_DEFAULT_MODULATION_DEPTH =    (0.0f);
+
+enum AL_EAXREVERB_MIN_AIR_ABSORPTION_GAINHF =   (0.892f);
+enum AL_EAXREVERB_MAX_AIR_ABSORPTION_GAINHF =   (1.0f);
+enum AL_EAXREVERB_DEFAULT_AIR_ABSORPTION_GAINHF = (0.994f);
+
+enum AL_EAXREVERB_MIN_HFREFERENCE =             (1000.0f);
+enum AL_EAXREVERB_MAX_HFREFERENCE =             (20000.0f);
+enum AL_EAXREVERB_DEFAULT_HFREFERENCE =         (5000.0f);
+
+enum AL_EAXREVERB_MIN_LFREFERENCE =             (20.0f);
+enum AL_EAXREVERB_MAX_LFREFERENCE =             (1000.0f);
+enum AL_EAXREVERB_DEFAULT_LFREFERENCE =         (250.0f);
+
+enum AL_EAXREVERB_MIN_ROOM_ROLLOFF_FACTOR =     (0.0f);
+enum AL_EAXREVERB_MAX_ROOM_ROLLOFF_FACTOR =     (10.0f);
+enum AL_EAXREVERB_DEFAULT_ROOM_ROLLOFF_FACTOR = (0.0f);
+
+enum AL_EAXREVERB_MIN_DECAY_HFLIMIT =           AL_FALSE;
+enum AL_EAXREVERB_MAX_DECAY_HFLIMIT =           AL_TRUE;
+enum AL_EAXREVERB_DEFAULT_DECAY_HFLIMIT =       AL_TRUE;
+
+/* Chorus effect */
+enum AL_CHORUS_WAVEFORM_SINUSOID =              (0);
+enum AL_CHORUS_WAVEFORM_TRIANGLE =              (1);
+
+enum AL_CHORUS_MIN_WAVEFORM =                   (0);
+enum AL_CHORUS_MAX_WAVEFORM =                   (1);
+enum AL_CHORUS_DEFAULT_WAVEFORM =               (1);
+
+enum AL_CHORUS_MIN_PHASE =                      (-180);
+enum AL_CHORUS_MAX_PHASE =                      (180);
+enum AL_CHORUS_DEFAULT_PHASE =                  (90);
+
+enum AL_CHORUS_MIN_RATE =                       (0.0f);
+enum AL_CHORUS_MAX_RATE =                       (10.0f);
+enum AL_CHORUS_DEFAULT_RATE =                   (1.1f);
+
+enum AL_CHORUS_MIN_DEPTH =                      (0.0f);
+enum AL_CHORUS_MAX_DEPTH =                      (1.0f);
+enum AL_CHORUS_DEFAULT_DEPTH =                  (0.1f);
+
+enum AL_CHORUS_MIN_FEEDBACK =                   (-1.0f);
+enum AL_CHORUS_MAX_FEEDBACK =                   (1.0f);
+enum AL_CHORUS_DEFAULT_FEEDBACK =               (0.25f);
+
+enum AL_CHORUS_MIN_DELAY =                      (0.0f);
+enum AL_CHORUS_MAX_DELAY =                      (0.016f);
+enum AL_CHORUS_DEFAULT_DELAY =                  (0.016f);
+
+/* Distortion effect */
+enum AL_DISTORTION_MIN_EDGE =                   (0.0f);
+enum AL_DISTORTION_MAX_EDGE =                   (1.0f);
+enum AL_DISTORTION_DEFAULT_EDGE =               (0.2f);
+
+enum AL_DISTORTION_MIN_GAIN =                   (0.01f);
+enum AL_DISTORTION_MAX_GAIN =                   (1.0f);
+enum AL_DISTORTION_DEFAULT_GAIN =               (0.05f);
+
+enum AL_DISTORTION_MIN_LOWPASS_CUTOFF =         (80.0f);
+enum AL_DISTORTION_MAX_LOWPASS_CUTOFF =         (24000.0f);
+enum AL_DISTORTION_DEFAULT_LOWPASS_CUTOFF =     (8000.0f);
+
+enum AL_DISTORTION_MIN_EQCENTER =               (80.0f);
+enum AL_DISTORTION_MAX_EQCENTER =               (24000.0f);
+enum AL_DISTORTION_DEFAULT_EQCENTER =           (3600.0f);
+
+enum AL_DISTORTION_MIN_EQBANDWIDTH =            (80.0f);
+enum AL_DISTORTION_MAX_EQBANDWIDTH =            (24000.0f);
+enum AL_DISTORTION_DEFAULT_EQBANDWIDTH =        (3600.0f);
+
+/* Echo effect */
+enum AL_ECHO_MIN_DELAY =                        (0.0f);
+enum AL_ECHO_MAX_DELAY =                        (0.207f);
+enum AL_ECHO_DEFAULT_DELAY =                    (0.1f);
+
+enum AL_ECHO_MIN_LRDELAY =                      (0.0f);
+enum AL_ECHO_MAX_LRDELAY =                      (0.404f);
+enum AL_ECHO_DEFAULT_LRDELAY =                  (0.1f);
+
+enum AL_ECHO_MIN_DAMPING =                      (0.0f);
+enum AL_ECHO_MAX_DAMPING =                      (0.99f);
+enum AL_ECHO_DEFAULT_DAMPING =                  (0.5f);
+
+enum AL_ECHO_MIN_FEEDBACK =                     (0.0f);
+enum AL_ECHO_MAX_FEEDBACK =                     (1.0f);
+enum AL_ECHO_DEFAULT_FEEDBACK =                 (0.5f);
+
+enum AL_ECHO_MIN_SPREAD =                       (-1.0f);
+enum AL_ECHO_MAX_SPREAD =                       (1.0f);
+enum AL_ECHO_DEFAULT_SPREAD =                   (-1.0f);
+
+/* Flanger effect */
+enum AL_FLANGER_WAVEFORM_SINUSOID =             (0);
+enum AL_FLANGER_WAVEFORM_TRIANGLE =             (1);
+
+enum AL_FLANGER_MIN_WAVEFORM =                  (0);
+enum AL_FLANGER_MAX_WAVEFORM =                  (1);
+enum AL_FLANGER_DEFAULT_WAVEFORM =              (1);
+
+enum AL_FLANGER_MIN_PHASE =                     (-180);
+enum AL_FLANGER_MAX_PHASE =                     (180);
+enum AL_FLANGER_DEFAULT_PHASE =                 (0);
+
+enum AL_FLANGER_MIN_RATE =                      (0.0f);
+enum AL_FLANGER_MAX_RATE =                      (10.0f);
+enum AL_FLANGER_DEFAULT_RATE =                  (0.27f);
+
+enum AL_FLANGER_MIN_DEPTH =                     (0.0f);
+enum AL_FLANGER_MAX_DEPTH =                     (1.0f);
+enum AL_FLANGER_DEFAULT_DEPTH =                 (1.0f);
+
+enum AL_FLANGER_MIN_FEEDBACK =                  (-1.0f);
+enum AL_FLANGER_MAX_FEEDBACK =                  (1.0f);
+enum AL_FLANGER_DEFAULT_FEEDBACK =              (-0.5f);
+
+enum AL_FLANGER_MIN_DELAY =                     (0.0f);
+enum AL_FLANGER_MAX_DELAY =                     (0.004f);
+enum AL_FLANGER_DEFAULT_DELAY =                 (0.002f);
+
+/* Frequency shifter effect */
+enum AL_FREQUENCY_SHIFTER_MIN_FREQUENCY =       (0.0f);
+enum AL_FREQUENCY_SHIFTER_MAX_FREQUENCY =       (24000.0f);
+enum AL_FREQUENCY_SHIFTER_DEFAULT_FREQUENCY =   (0.0f);
+
+enum AL_FREQUENCY_SHIFTER_MIN_LEFT_DIRECTION =  (0);
+enum AL_FREQUENCY_SHIFTER_MAX_LEFT_DIRECTION =  (2);
+enum AL_FREQUENCY_SHIFTER_DEFAULT_LEFT_DIRECTION = (0);
+
+enum AL_FREQUENCY_SHIFTER_DIRECTION_DOWN =      (0);
+enum AL_FREQUENCY_SHIFTER_DIRECTION_UP =        (1);
+enum AL_FREQUENCY_SHIFTER_DIRECTION_OFF =       (2);
+
+enum AL_FREQUENCY_SHIFTER_MIN_RIGHT_DIRECTION = (0);
+enum AL_FREQUENCY_SHIFTER_MAX_RIGHT_DIRECTION = (2);
+enum AL_FREQUENCY_SHIFTER_DEFAULT_RIGHT_DIRECTION = (0);
+
+/* Vocal morpher effect */
+enum AL_VOCAL_MORPHER_MIN_PHONEMEA =            (0);
+enum AL_VOCAL_MORPHER_MAX_PHONEMEA =            (29);
+enum AL_VOCAL_MORPHER_DEFAULT_PHONEMEA =        (0);
+
+enum AL_VOCAL_MORPHER_MIN_PHONEMEA_COARSE_TUNING = (-24);
+enum AL_VOCAL_MORPHER_MAX_PHONEMEA_COARSE_TUNING = (24);
+enum AL_VOCAL_MORPHER_DEFAULT_PHONEMEA_COARSE_TUNING = (0);
+
+enum AL_VOCAL_MORPHER_MIN_PHONEMEB =            (0);
+enum AL_VOCAL_MORPHER_MAX_PHONEMEB =            (29);
+enum AL_VOCAL_MORPHER_DEFAULT_PHONEMEB =        (10);
+
+enum AL_VOCAL_MORPHER_MIN_PHONEMEB_COARSE_TUNING = (-24);
+enum AL_VOCAL_MORPHER_MAX_PHONEMEB_COARSE_TUNING = (24);
+enum AL_VOCAL_MORPHER_DEFAULT_PHONEMEB_COARSE_TUNING = (0);
+
+enum AL_VOCAL_MORPHER_PHONEME_A =               (0);
+enum AL_VOCAL_MORPHER_PHONEME_E =               (1);
+enum AL_VOCAL_MORPHER_PHONEME_I =               (2);
+enum AL_VOCAL_MORPHER_PHONEME_O =               (3);
+enum AL_VOCAL_MORPHER_PHONEME_U =               (4);
+enum AL_VOCAL_MORPHER_PHONEME_AA =              (5);
+enum AL_VOCAL_MORPHER_PHONEME_AE =              (6);
+enum AL_VOCAL_MORPHER_PHONEME_AH =              (7);
+enum AL_VOCAL_MORPHER_PHONEME_AO =              (8);
+enum AL_VOCAL_MORPHER_PHONEME_EH =              (9);
+enum AL_VOCAL_MORPHER_PHONEME_ER =              (10);
+enum AL_VOCAL_MORPHER_PHONEME_IH =              (11);
+enum AL_VOCAL_MORPHER_PHONEME_IY =              (12);
+enum AL_VOCAL_MORPHER_PHONEME_UH =              (13);
+enum AL_VOCAL_MORPHER_PHONEME_UW =              (14);
+enum AL_VOCAL_MORPHER_PHONEME_B =               (15);
+enum AL_VOCAL_MORPHER_PHONEME_D =               (16);
+enum AL_VOCAL_MORPHER_PHONEME_F =               (17);
+enum AL_VOCAL_MORPHER_PHONEME_G =               (18);
+enum AL_VOCAL_MORPHER_PHONEME_J =               (19);
+enum AL_VOCAL_MORPHER_PHONEME_K =               (20);
+enum AL_VOCAL_MORPHER_PHONEME_L =               (21);
+enum AL_VOCAL_MORPHER_PHONEME_M =               (22);
+enum AL_VOCAL_MORPHER_PHONEME_N =               (23);
+enum AL_VOCAL_MORPHER_PHONEME_P =               (24);
+enum AL_VOCAL_MORPHER_PHONEME_R =               (25);
+enum AL_VOCAL_MORPHER_PHONEME_S =               (26);
+enum AL_VOCAL_MORPHER_PHONEME_T =               (27);
+enum AL_VOCAL_MORPHER_PHONEME_V =               (28);
+enum AL_VOCAL_MORPHER_PHONEME_Z =               (29);
+
+enum AL_VOCAL_MORPHER_WAVEFORM_SINUSOID =       (0);
+enum AL_VOCAL_MORPHER_WAVEFORM_TRIANGLE =       (1);
+enum AL_VOCAL_MORPHER_WAVEFORM_SAWTOOTH =       (2);
+
+enum AL_VOCAL_MORPHER_MIN_WAVEFORM =            (0);
+enum AL_VOCAL_MORPHER_MAX_WAVEFORM =            (2);
+enum AL_VOCAL_MORPHER_DEFAULT_WAVEFORM =        (0);
+
+enum AL_VOCAL_MORPHER_MIN_RATE =                (0.0f);
+enum AL_VOCAL_MORPHER_MAX_RATE =                (10.0f);
+enum AL_VOCAL_MORPHER_DEFAULT_RATE =            (1.41f);
+
+/* Pitch shifter effect */
+enum AL_PITCH_SHIFTER_MIN_COARSE_TUNE =         (-12);
+enum AL_PITCH_SHIFTER_MAX_COARSE_TUNE =         (12);
+enum AL_PITCH_SHIFTER_DEFAULT_COARSE_TUNE =     (12);
+
+enum AL_PITCH_SHIFTER_MIN_FINE_TUNE =           (-50);
+enum AL_PITCH_SHIFTER_MAX_FINE_TUNE =           (50);
+enum AL_PITCH_SHIFTER_DEFAULT_FINE_TUNE =       (0);
+
+/* Ring modulator effect */
+enum AL_RING_MODULATOR_MIN_FREQUENCY =          (0.0f);
+enum AL_RING_MODULATOR_MAX_FREQUENCY =          (8000.0f);
+enum AL_RING_MODULATOR_DEFAULT_FREQUENCY =      (440.0f);
+
+enum AL_RING_MODULATOR_MIN_HIGHPASS_CUTOFF =    (0.0f);
+enum AL_RING_MODULATOR_MAX_HIGHPASS_CUTOFF =    (24000.0f);
+enum AL_RING_MODULATOR_DEFAULT_HIGHPASS_CUTOFF = (800.0f);
+
+enum AL_RING_MODULATOR_SINUSOID =               (0);
+enum AL_RING_MODULATOR_SAWTOOTH =               (1);
+enum AL_RING_MODULATOR_SQUARE =                 (2);
+
+enum AL_RING_MODULATOR_MIN_WAVEFORM =           (0);
+enum AL_RING_MODULATOR_MAX_WAVEFORM =           (2);
+enum AL_RING_MODULATOR_DEFAULT_WAVEFORM =       (0);
+
+/* Autowah effect */
+enum AL_AUTOWAH_MIN_ATTACK_TIME =               (0.0001f);
+enum AL_AUTOWAH_MAX_ATTACK_TIME =               (1.0f);
+enum AL_AUTOWAH_DEFAULT_ATTACK_TIME =           (0.06f);
+
+enum AL_AUTOWAH_MIN_RELEASE_TIME =              (0.0001f);
+enum AL_AUTOWAH_MAX_RELEASE_TIME =              (1.0f);
+enum AL_AUTOWAH_DEFAULT_RELEASE_TIME =          (0.06f);
+
+enum AL_AUTOWAH_MIN_RESONANCE =                 (2.0f);
+enum AL_AUTOWAH_MAX_RESONANCE =                 (1000.0f);
+enum AL_AUTOWAH_DEFAULT_RESONANCE =             (1000.0f);
+
+enum AL_AUTOWAH_MIN_PEAK_GAIN =                 (0.00003f);
+enum AL_AUTOWAH_MAX_PEAK_GAIN =                 (31621.0f);
+enum AL_AUTOWAH_DEFAULT_PEAK_GAIN =             (11.22f);
+
+/* Compressor effect */
+enum AL_COMPRESSOR_MIN_ONOFF =                  (0);
+enum AL_COMPRESSOR_MAX_ONOFF =                  (1);
+enum AL_COMPRESSOR_DEFAULT_ONOFF =              (1);
+
+/* Equalizer effect */
+enum AL_EQUALIZER_MIN_LOW_GAIN =                (0.126f);
+enum AL_EQUALIZER_MAX_LOW_GAIN =                (7.943f);
+enum AL_EQUALIZER_DEFAULT_LOW_GAIN =            (1.0f);
+
+enum AL_EQUALIZER_MIN_LOW_CUTOFF =              (50.0f);
+enum AL_EQUALIZER_MAX_LOW_CUTOFF =              (800.0f);
+enum AL_EQUALIZER_DEFAULT_LOW_CUTOFF =          (200.0f);
+
+enum AL_EQUALIZER_MIN_MID1_GAIN =               (0.126f);
+enum AL_EQUALIZER_MAX_MID1_GAIN =               (7.943f);
+enum AL_EQUALIZER_DEFAULT_MID1_GAIN =           (1.0f);
+
+enum AL_EQUALIZER_MIN_MID1_CENTER =             (200.0f);
+enum AL_EQUALIZER_MAX_MID1_CENTER =             (3000.0f);
+enum AL_EQUALIZER_DEFAULT_MID1_CENTER =         (500.0f);
+
+enum AL_EQUALIZER_MIN_MID1_WIDTH =              (0.01f);
+enum AL_EQUALIZER_MAX_MID1_WIDTH =              (1.0f);
+enum AL_EQUALIZER_DEFAULT_MID1_WIDTH =          (1.0f);
+
+enum AL_EQUALIZER_MIN_MID2_GAIN =               (0.126f);
+enum AL_EQUALIZER_MAX_MID2_GAIN =               (7.943f);
+enum AL_EQUALIZER_DEFAULT_MID2_GAIN =           (1.0f);
+
+enum AL_EQUALIZER_MIN_MID2_CENTER =             (1000.0f);
+enum AL_EQUALIZER_MAX_MID2_CENTER =             (8000.0f);
+enum AL_EQUALIZER_DEFAULT_MID2_CENTER =         (3000.0f);
+
+enum AL_EQUALIZER_MIN_MID2_WIDTH =              (0.01f);
+enum AL_EQUALIZER_MAX_MID2_WIDTH =              (1.0f);
+enum AL_EQUALIZER_DEFAULT_MID2_WIDTH =          (1.0f);
+
+enum AL_EQUALIZER_MIN_HIGH_GAIN =               (0.126f);
+enum AL_EQUALIZER_MAX_HIGH_GAIN =               (7.943f);
+enum AL_EQUALIZER_DEFAULT_HIGH_GAIN =           (1.0f);
+
+enum AL_EQUALIZER_MIN_HIGH_CUTOFF =             (4000.0f);
+enum AL_EQUALIZER_MAX_HIGH_CUTOFF =             (16000.0f);
+enum AL_EQUALIZER_DEFAULT_HIGH_CUTOFF =         (6000.0f);
+
+
+/* Source parameter value ranges and defaults. */
+enum AL_MIN_AIR_ABSORPTION_FACTOR =             (0.0f);
+enum AL_MAX_AIR_ABSORPTION_FACTOR =             (10.0f);
+enum AL_DEFAULT_AIR_ABSORPTION_FACTOR =         (0.0f);
+
+enum AL_MIN_ROOM_ROLLOFF_FACTOR =               (0.0f);
+enum AL_MAX_ROOM_ROLLOFF_FACTOR =               (10.0f);
+enum AL_DEFAULT_ROOM_ROLLOFF_FACTOR =           (0.0f);
+
+enum AL_MIN_CONE_OUTER_GAINHF =                 (0.0f);
+enum AL_MAX_CONE_OUTER_GAINHF =                 (1.0f);
+enum AL_DEFAULT_CONE_OUTER_GAINHF =             (1.0f);
+
+enum AL_MIN_DIRECT_FILTER_GAINHF_AUTO =         AL_FALSE;
+enum AL_MAX_DIRECT_FILTER_GAINHF_AUTO =         AL_TRUE;
+enum AL_DEFAULT_DIRECT_FILTER_GAINHF_AUTO =     AL_TRUE;
+
+enum AL_MIN_AUXILIARY_SEND_FILTER_GAIN_AUTO =   AL_FALSE;
+enum AL_MAX_AUXILIARY_SEND_FILTER_GAIN_AUTO =   AL_TRUE;
+enum AL_DEFAULT_AUXILIARY_SEND_FILTER_GAIN_AUTO = AL_TRUE;
+
+enum AL_MIN_AUXILIARY_SEND_FILTER_GAINHF_AUTO = AL_FALSE;
+enum AL_MAX_AUXILIARY_SEND_FILTER_GAINHF_AUTO = AL_TRUE;
+enum AL_DEFAULT_AUXILIARY_SEND_FILTER_GAINHF_AUTO = AL_TRUE;
+
+
+/* Listener parameter value ranges and defaults. */
+enum AL_MIN_METERS_PER_UNIT =                   float.min_normal;
+enum AL_MAX_METERS_PER_UNIT =                   float.max;
+enum AL_DEFAULT_METERS_PER_UNIT =               (1.0f);

--- a/source/bindbc/openal/package.d
+++ b/source/bindbc/openal/package.d
@@ -7,6 +7,8 @@
 module bindbc.openal;
 
 public import bindbc.openal.types;
+public import bindbc.openal.efx;
+public import bindbc.openal.presets;
 
 version(BindBC_Static) version = BindOpenAL_Static;
 version(BindOpenAL_Static) public import bindbc.openal.bindstatic;

--- a/source/bindbc/openal/presets.d
+++ b/source/bindbc/openal/presets.d
@@ -1,0 +1,846 @@
+module bindbc.openal.presets;
+
+/**
+* Prsets came from OpenAL Soft repository
+*/
+struct ReverbProperties
+{
+    float density;
+    float diffusion;
+    float gain;
+    float gainHF;
+    float gainLF;
+    float decayTime;
+    float decayHFRatio;
+    float decayLFRatio;
+    float reflectionsGain;
+    float reflectionsDelay;
+    float[3] reflectionsPan;
+    float lateReverbGain;
+    float lateReverbDelay;
+    float[3] lateReverbPan;
+    float echoTime;
+    float echoDepth;
+    float modulationTime;
+    float modulationDepth;
+    float airAbsorptionGainHF;
+    float HFReference;
+    float LFReference;
+    float roomRolloffFactor;
+    int   decayHFLimit;
+
+    static ReverbProperties GENERIC()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.8913f, 1.0000f, 1.4900f, 0.8300f, 1.0000f, 0.0500f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+         1.2589f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+    }
+
+    static ReverbProperties PADDED_CELL()
+    {
+        return ReverbProperties(0.1715f, 1.0000f, 0.3162f, 0.0010f, 1.0000f, 0.1700f, 0.1000f, 1.0000f, 0.2500f, 0.0010f, [0.0000f, 0.0000f, 0.0000f],
+        1.2691f, 0.0020f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ROOM()
+    {
+        return ReverbProperties(0.4287f, 1.0000f, 0.3162f, 0.5929f, 1.0000f, 0.4000f, 0.8300f, 1.0000f, 0.1503f, 0.0020f, [0.0000f, 0.0000f, 0.0000f],
+        1.0629f, 0.0030f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties BATHROOM()
+    {
+        return ReverbProperties(0.1715f, 1.0000f, 0.3162f, 0.2512f, 1.0000f, 1.4900f, 0.5400f, 1.0000f, 0.6531f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        3.2734f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties LIVING_ROOM()
+    {
+        return ReverbProperties(0.9766f, 1.0000f, 0.3162f, 0.0010f, 1.0000f, 0.5000f, 0.1000f, 1.0000f, 0.2051f, 0.0030f, [0.0000f, 0.0000f, 0.0000f],
+        0.2805f, 0.0040f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties STONE_ROOM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.7079f, 1.0000f, 2.3100f, 0.6400f, 1.0000f, 0.4411f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.1003f, 0.0170f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties AUDITORIUM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.5781f, 1.0000f, 4.3200f, 0.5900f, 1.0000f, 0.4032f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        0.7170f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CONCERT_HALL()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.5623f, 1.0000f, 3.9200f, 0.7000f, 1.0000f, 0.2427f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        0.9977f, 0.0290f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CAVE()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 1.0000f, 1.0000f, 2.9100f, 1.3000f, 1.0000f, 0.5000f, 0.0150f, [0.0000f, 0.0000f, 0.0000f],
+        0.7063f, 0.0220f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+    }
+
+    static ReverbProperties ARENA()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.4477f, 1.0000f, 7.2400f, 0.3300f, 1.0000f, 0.2612f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        1.0186f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties HANGAR()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.3162f, 1.0000f, 10.0500f, 0.2300f, 1.0000f, 0.5000f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        1.2560f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CARPETEDHALLWAY()
+    {
+        return ReverbProperties(0.4287f, 1.0000f, 0.3162f, 0.0100f, 1.0000f, 0.3000f, 0.1000f, 1.0000f, 0.1215f, 0.0020f, [0.0000f, 0.0000f, 0.0000f],
+        0.1531f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties HALLWAY()
+    {
+        return ReverbProperties(0.3645f, 1.0000f, 0.3162f, 0.7079f, 1.0000f, 1.4900f, 0.5900f, 1.0000f, 0.2458f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.6615f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties STONECORRIDOR()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.7612f, 1.0000f, 2.7000f, 0.7900f, 1.0000f, 0.2472f, 0.0130f, [0.0000f, 0.0000f, 0.0000f],
+        1.5758f, 0.0200f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ALLEY()
+    {
+        return ReverbProperties(1.0000f, 0.3000f, 0.3162f, 0.7328f, 1.0000f, 1.4900f, 0.8600f, 1.0000f, 0.2500f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        0.9954f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.1250f, 0.9500f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FOREST()
+    {
+        return ReverbProperties(1.0000f, 0.3000f, 0.3162f, 0.0224f, 1.0000f, 1.4900f, 0.5400f, 1.0000f, 0.0525f, 0.1620f, [0.0000f, 0.0000f, 0.0000f],
+        0.7682f, 0.0880f, [0.0000f, 0.0000f, 0.0000f], 0.1250f, 1.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CITY()
+    {
+        return ReverbProperties(1.0000f, 0.5000f, 0.3162f, 0.3981f, 1.0000f, 1.4900f, 0.6700f, 1.0000f, 0.0730f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        0.1427f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties MOUNTAINS()
+    {
+        return ReverbProperties(1.0000f, 0.2700f, 0.3162f, 0.0562f, 1.0000f, 1.4900f, 0.2100f, 1.0000f, 0.0407f, 0.3000f, [0.0000f, 0.0000f, 0.0000f],
+        0.1919f, 0.1000f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 1.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties QUARRY()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.3162f, 1.0000f, 1.4900f, 0.8300f, 1.0000f, 0.0000f, 0.0610f, [0.0000f, 0.0000f, 0.0000f],
+        1.7783f, 0.0250f, [0.0000f, 0.0000f, 0.0000f], 0.1250f, 0.7000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties PLAIN()
+    {
+        return ReverbProperties(1.0000f, 0.2100f, 0.3162f, 0.1000f, 1.0000f, 1.4900f, 0.5000f, 1.0000f, 0.0585f, 0.1790f, [0.0000f, 0.0000f, 0.0000f],
+        0.1089f, 0.1000f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 1.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties PARKINGLOT()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 1.0000f, 1.0000f, 1.6500f, 1.5000f, 1.0000f, 0.2082f, 0.0080f, [0.0000f, 0.0000f, 0.0000f],
+        0.2652f, 0.0120f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties SEWERPIPE()
+    {
+        return ReverbProperties(0.3071f, 0.8000f, 0.3162f, 0.3162f, 1.0000f, 2.8100f, 0.1400f, 1.0000f, 1.6387f, 0.0140f, [0.0000f, 0.0000f, 0.0000f],
+        3.2471f, 0.0210f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties UNDERWATER()
+    {
+        return ReverbProperties(0.3645f, 1.0000f, 0.3162f, 0.0100f, 1.0000f, 1.4900f, 0.1000f, 1.0000f, 0.5963f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        7.0795f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 1.1800f, 0.3480f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties DRUGGED()
+    {
+        return ReverbProperties(0.4287f, 0.5000f, 0.3162f, 1.0000f, 1.0000f, 8.3900f, 1.3900f, 1.0000f, 0.8760f, 0.0020f, [0.0000f, 0.0000f, 0.0000f],
+        3.1081f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 1.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties DIZZY()
+    {
+        return ReverbProperties(0.3645f, 0.6000f, 0.3162f, 0.6310f, 1.0000f, 17.2300f, 0.5600f, 1.0000f, 0.1392f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        0.4937f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 1.0000f, 0.8100f, 0.3100f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties PSYCHOTIC()
+    {
+        return ReverbProperties(0.0625f, 0.5000f, 0.3162f, 0.8404f, 1.0000f, 7.5600f, 0.9100f, 1.0000f, 0.4864f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        2.4378f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 4.0000f, 1.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+/* Castle Presets */
+
+    static ReverbProperties CASTLE_SMALLROOM()
+    {
+        return ReverbProperties(1.0000f, 0.8900f, 0.3162f, 0.3981f, 0.1000f, 1.2200f, 0.8300f, 0.3100f, 0.8913f, 0.0220f, [0.0000f, 0.0000f, 0.0000f],
+        1.9953f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.1380f, 0.0800f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_SHORTPASSAGE()
+    {
+        return ReverbProperties(1.0000f, 0.8900f, 0.3162f, 0.3162f, 0.1000f, 2.3200f, 0.8300f, 0.3100f, 0.8913f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0230f, [0.0000f, 0.0000f, 0.0000f], 0.1380f, 0.0800f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_MEDIUMROOM()
+    {
+        return ReverbProperties(1.0000f, 0.9300f, 0.3162f, 0.2818f, 0.1000f, 2.0400f, 0.8300f, 0.4600f, 0.6310f, 0.0220f, [0.0000f, 0.0000f, 0.0000f],
+        1.5849f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.1550f, 0.0300f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_LARGEROOM()
+    {
+        return ReverbProperties(1.0000f, 0.8200f, 0.3162f, 0.2818f, 0.1259f, 2.5300f, 0.8300f, 0.5000f, 0.4467f, 0.0340f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0160f, [0.0000f, 0.0000f, 0.0000f], 0.1850f, 0.0700f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_LONGPASSAGE()
+    {
+        return ReverbProperties(1.0000f, 0.8900f, 0.3162f, 0.3981f, 0.1000f, 3.4200f, 0.8300f, 0.3100f, 0.8913f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0230f, [0.0000f, 0.0000f, 0.0000f], 0.1380f, 0.0800f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_HALL()
+    {
+        return ReverbProperties(1.0000f, 0.8100f, 0.3162f, 0.2818f, 0.1778f, 3.1400f, 0.7900f, 0.6200f, 0.1778f, 0.0560f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0240f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_CUPBOARD()
+    {
+        return ReverbProperties(1.0000f, 0.8900f, 0.3162f, 0.2818f, 0.1000f, 0.6700f, 0.8700f, 0.3100f, 1.4125f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        3.5481f, 0.0070f, [0.0000f, 0.0000f, 0.0000f], 0.1380f, 0.0800f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CASTLE_COURTYARD()
+    {
+        return ReverbProperties(1.0000f, 0.4200f, 0.3162f, 0.4467f, 0.1995f, 2.1300f, 0.6100f, 0.2300f, 0.2239f, 0.1600f, [0.0000f, 0.0000f, 0.0000f],
+        0.7079f, 0.0360f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.3700f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties CASTLE_ALCOVE()
+    {
+        return ReverbProperties(1.0000f, 0.8900f, 0.3162f, 0.5012f, 0.1000f, 1.6400f, 0.8700f, 0.3100f, 1.0000f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0340f, [0.0000f, 0.0000f, 0.0000f], 0.1380f, 0.0800f, 0.2500f, 0.0000f, 0.9943f, 5168.6001f, 139.5000f, 0.0000f, 0x1 );
+
+    }
+
+/* Factory Presets */
+
+    static ReverbProperties FACTORY_SMALLROOM()
+    {
+        return ReverbProperties(0.3645f, 0.8200f, 0.3162f, 0.7943f, 0.5012f, 1.7200f, 0.6500f, 1.3100f, 0.7079f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.7783f, 0.0240f, [0.0000f, 0.0000f, 0.0000f], 0.1190f, 0.0700f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_SHORTPASSAGE()
+    {
+        return ReverbProperties(0.3645f, 0.6400f, 0.2512f, 0.7943f, 0.5012f, 2.5300f, 0.6500f, 1.3100f, 1.0000f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0380f, [0.0000f, 0.0000f, 0.0000f], 0.1350f, 0.2300f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_MEDIUMROOM()
+    {
+        return ReverbProperties(0.4287f, 0.8200f, 0.2512f, 0.7943f, 0.5012f, 2.7600f, 0.6500f, 1.3100f, 0.2818f, 0.0220f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0230f, [0.0000f, 0.0000f, 0.0000f], 0.1740f, 0.0700f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_LARGEROOM()
+    {
+        return ReverbProperties(0.4287f, 0.7500f, 0.2512f, 0.7079f, 0.6310f, 4.2400f, 0.5100f, 1.3100f, 0.1778f, 0.0390f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0230f, [0.0000f, 0.0000f, 0.0000f], 0.2310f, 0.0700f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_LONGPASSAGE()
+    {
+        return ReverbProperties(0.3645f, 0.6400f, 0.2512f, 0.7943f, 0.5012f, 4.0600f, 0.6500f, 1.3100f, 1.0000f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0370f, [0.0000f, 0.0000f, 0.0000f], 0.1350f, 0.2300f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_HALL()
+    {
+        return ReverbProperties(0.4287f, 0.7500f, 0.3162f, 0.7079f, 0.6310f, 7.4300f, 0.5100f, 1.3100f, 0.0631f, 0.0730f, [0.0000f, 0.0000f, 0.0000f],
+        0.8913f, 0.0270f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0700f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_CUPBOARD()
+    {
+        return ReverbProperties(0.3071f, 0.6300f, 0.2512f, 0.7943f, 0.5012f, 0.4900f, 0.6500f, 1.3100f, 1.2589f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.9953f, 0.0320f, [0.0000f, 0.0000f, 0.0000f], 0.1070f, 0.0700f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_COURTYARD()
+    {
+        return ReverbProperties(0.3071f, 0.5700f, 0.3162f, 0.3162f, 0.6310f, 2.3200f, 0.2900f, 0.5600f, 0.2239f, 0.1400f, [0.0000f, 0.0000f, 0.0000f],
+        0.3981f, 0.0390f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.2900f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties FACTORY_ALCOVE()
+    {
+        return ReverbProperties(0.3645f, 0.5900f, 0.2512f, 0.7943f, 0.5012f, 3.1400f, 0.6500f, 1.3100f, 1.4125f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.0000f, 0.0380f, [0.0000f, 0.0000f, 0.0000f], 0.1140f, 0.1000f, 0.2500f, 0.0000f, 0.9943f, 3762.6001f, 362.5000f, 0.0000f, 0x1 );
+
+    }
+
+/* Ice Palace Presets */
+
+    static ReverbProperties ICEPALACE_SMALLROOM()
+    {
+        return ReverbProperties(1.0000f, 0.8400f, 0.3162f, 0.5623f, 0.2818f, 1.5100f, 1.5300f, 0.2700f, 0.8913f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.1640f, 0.1400f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_SHORTPASSAGE()
+    {
+        return ReverbProperties(1.0000f, 0.7500f, 0.3162f, 0.5623f, 0.2818f, 1.7900f, 1.4600f, 0.2800f, 0.5012f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0190f, [0.0000f, 0.0000f, 0.0000f], 0.1770f, 0.0900f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_MEDIUMROOM()
+    {
+        return ReverbProperties(1.0000f, 0.8700f, 0.3162f, 0.5623f, 0.4467f, 2.2200f, 1.5300f, 0.3200f, 0.3981f, 0.0390f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0270f, [0.0000f, 0.0000f, 0.0000f], 0.1860f, 0.1200f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_LARGEROOM()
+    {
+        return ReverbProperties(1.0000f, 0.8100f, 0.3162f, 0.5623f, 0.4467f, 3.1400f, 1.5300f, 0.3200f, 0.2512f, 0.0390f, [0.0000f, 0.0000f, 0.0000f],
+        1.0000f, 0.0270f, [0.0000f, 0.0000f, 0.0000f], 0.2140f, 0.1100f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_LONGPASSAGE()
+    {
+        return ReverbProperties(1.0000f, 0.7700f, 0.3162f, 0.5623f, 0.3981f, 3.0100f, 1.4600f, 0.2800f, 0.7943f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0250f, [0.0000f, 0.0000f, 0.0000f], 0.1860f, 0.0400f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_HALL()
+    {
+        return ReverbProperties(1.0000f, 0.7600f, 0.3162f, 0.4467f, 0.5623f, 5.4900f, 1.5300f, 0.3800f, 0.1122f, 0.0540f, [0.0000f, 0.0000f, 0.0000f],
+        0.6310f, 0.0520f, [0.0000f, 0.0000f, 0.0000f], 0.2260f, 0.1100f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_CUPBOARD()
+    {
+        return ReverbProperties(1.0000f, 0.8300f, 0.3162f, 0.5012f, 0.2239f, 0.7600f, 1.5300f, 0.2600f, 1.1220f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.9953f, 0.0160f, [0.0000f, 0.0000f, 0.0000f], 0.1430f, 0.0800f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_COURTYARD()
+    {
+        return ReverbProperties(1.0000f, 0.5900f, 0.3162f, 0.2818f, 0.3162f, 2.0400f, 1.2000f, 0.3800f, 0.3162f, 0.1730f, [0.0000f, 0.0000f, 0.0000f],
+        0.3162f, 0.0430f, [0.0000f, 0.0000f, 0.0000f], 0.2350f, 0.4800f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties ICEPALACE_ALCOVE()
+    {
+        return ReverbProperties(1.0000f, 0.8400f, 0.3162f, 0.5623f, 0.2818f, 2.7600f, 1.4600f, 0.2800f, 1.1220f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        0.8913f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.1610f, 0.0900f, 0.2500f, 0.0000f, 0.9943f, 12428.5000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+/* Space Station Presets */
+
+    static ReverbProperties SPACESTATION_SMALLROOM()
+    {
+        return ReverbProperties(0.2109f, 0.7000f, 0.3162f, 0.7079f, 0.8913f, 1.7200f, 0.8200f, 0.5500f, 0.7943f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0130f, [0.0000f, 0.0000f, 0.0000f], 0.1880f, 0.2600f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_SHORTPASSAGE()
+    {
+        return ReverbProperties(0.2109f, 0.8700f, 0.3162f, 0.6310f, 0.8913f, 3.5700f, 0.5000f, 0.5500f, 1.0000f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0160f, [0.0000f, 0.0000f, 0.0000f], 0.1720f, 0.2000f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_MEDIUMROOM()
+    {
+        return ReverbProperties(0.2109f, 0.7500f, 0.3162f, 0.6310f, 0.8913f, 3.0100f, 0.5000f, 0.5500f, 0.3981f, 0.0340f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0350f, [0.0000f, 0.0000f, 0.0000f], 0.2090f, 0.3100f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_LARGEROOM()
+    {
+        return ReverbProperties(0.3645f, 0.8100f, 0.3162f, 0.6310f, 0.8913f, 3.8900f, 0.3800f, 0.6100f, 0.3162f, 0.0560f, [0.0000f, 0.0000f, 0.0000f],
+        0.8913f, 0.0350f, [0.0000f, 0.0000f, 0.0000f], 0.2330f, 0.2800f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_LONGPASSAGE()
+    {
+        return ReverbProperties(0.4287f, 0.8200f, 0.3162f, 0.6310f, 0.8913f, 4.6200f, 0.6200f, 0.5500f, 1.0000f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0310f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.2300f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_HALL()
+    {
+        return ReverbProperties(0.4287f, 0.8700f, 0.3162f, 0.6310f, 0.8913f, 7.1100f, 0.3800f, 0.6100f, 0.1778f, 0.1000f, [0.0000f, 0.0000f, 0.0000f],
+        0.6310f, 0.0470f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.2500f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_CUPBOARD()
+    {
+        return ReverbProperties(0.1715f, 0.5600f, 0.3162f, 0.7079f, 0.8913f, 0.7900f, 0.8100f, 0.5500f, 1.4125f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.7783f, 0.0180f, [0.0000f, 0.0000f, 0.0000f], 0.1810f, 0.3100f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPACESTATION_ALCOVE()
+    {
+        return ReverbProperties(0.2109f, 0.7800f, 0.3162f, 0.7079f, 0.8913f, 1.1600f, 0.8100f, 0.5500f, 1.4125f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        1.0000f, 0.0180f, [0.0000f, 0.0000f, 0.0000f], 0.1920f, 0.2100f, 0.2500f, 0.0000f, 0.9943f, 3316.1001f, 458.2000f, 0.0000f, 0x1 );
+
+    }
+
+/* Wooden Galleon Presets */
+
+    static ReverbProperties WOODEN_SMALLROOM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.1122f, 0.3162f, 0.7900f, 0.3200f, 0.8700f, 1.0000f, 0.0320f, [0.0000f, 0.0000f, 0.0000f],
+        0.8913f, 0.0290f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_SHORTPASSAGE()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.1259f, 0.3162f, 1.7500f, 0.5000f, 0.8700f, 0.8913f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        0.6310f, 0.0240f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_MEDIUMROOM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.1000f, 0.2818f, 1.4700f, 0.4200f, 0.8200f, 0.8913f, 0.0490f, [0.0000f, 0.0000f, 0.0000f],
+        0.8913f, 0.0290f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_LARGEROOM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.0891f, 0.2818f, 2.6500f, 0.3300f, 0.8200f, 0.8913f, 0.0660f, [0.0000f, 0.0000f, 0.0000f],
+        0.7943f, 0.0490f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_LONGPASSAGE()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.1000f, 0.3162f, 1.9900f, 0.4000f, 0.7900f, 1.0000f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        0.4467f, 0.0360f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_HALL()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.0794f, 0.2818f, 3.4500f, 0.3000f, 0.8200f, 0.8913f, 0.0880f, [0.0000f, 0.0000f, 0.0000f],
+        0.7943f, 0.0630f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_CUPBOARD()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.1413f, 0.3162f, 0.5600f, 0.4600f, 0.9100f, 1.1220f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0280f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_COURTYARD()
+    {
+        return ReverbProperties(1.0000f, 0.6500f, 0.3162f, 0.0794f, 0.3162f, 1.7900f, 0.3500f, 0.7900f, 0.5623f, 0.1230f, [0.0000f, 0.0000f, 0.0000f],
+        0.1000f, 0.0320f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties WOODEN_ALCOVE()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.1259f, 0.3162f, 1.2200f, 0.6200f, 0.9100f, 1.1220f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        0.7079f, 0.0240f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 4705.0000f, 99.6000f, 0.0000f, 0x1 );
+
+    }
+
+/* Sports Presets */
+
+    static ReverbProperties SPORT_EMPTYSTADIUM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.4467f, 0.7943f, 6.2600f, 0.5100f, 1.1000f, 0.0631f, 0.1830f, [0.0000f, 0.0000f, 0.0000f],
+        0.3981f, 0.0380f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPORT_SQUASHCOURT()
+    {
+        return ReverbProperties(1.0000f, 0.7500f, 0.3162f, 0.3162f, 0.7943f, 2.2200f, 0.9100f, 1.1600f, 0.4467f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        0.7943f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.1260f, 0.1900f, 0.2500f, 0.0000f, 0.9943f, 7176.8999f, 211.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPORT_SMALLSWIMMINGPOOL()
+    {
+        return ReverbProperties(1.0000f, 0.7000f, 0.3162f, 0.7943f, 0.8913f, 2.7600f, 1.2500f, 1.1400f, 0.6310f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        0.7943f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.1790f, 0.1500f, 0.8950f, 0.1900f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties SPORT_LARGESWIMMINGPOOL()
+    {
+        return ReverbProperties(1.0000f, 0.8200f, 0.3162f, 0.7943f, 1.0000f, 5.4900f, 1.3100f, 1.1400f, 0.4467f, 0.0390f, [0.0000f, 0.0000f, 0.0000f],
+        0.5012f, 0.0490f, [0.0000f, 0.0000f, 0.0000f], 0.2220f, 0.5500f, 1.1590f, 0.2100f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties SPORT_GYMNASIUM()
+    {
+        return ReverbProperties(1.0000f, 0.8100f, 0.3162f, 0.4467f, 0.8913f, 3.1400f, 1.0600f, 1.3500f, 0.3981f, 0.0290f, [0.0000f, 0.0000f, 0.0000f],
+        0.5623f, 0.0450f, [0.0000f, 0.0000f, 0.0000f], 0.1460f, 0.1400f, 0.2500f, 0.0000f, 0.9943f, 7176.8999f, 211.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPORT_FULLSTADIUM()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.0708f, 0.7943f, 5.2500f, 0.1700f, 0.8000f, 0.1000f, 0.1880f, [0.0000f, 0.0000f, 0.0000f],
+        0.2818f, 0.0380f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SPORT_STADIUMTANNOY()
+    {
+        return ReverbProperties(1.0000f, 0.7800f, 0.3162f, 0.5623f, 0.5012f, 2.5300f, 0.8800f, 0.6800f, 0.2818f, 0.2300f, [0.0000f, 0.0000f, 0.0000f],
+        0.5012f, 0.0630f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.2000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+/* Prefab Presets */
+
+    static ReverbProperties PREFAB_WORKSHOP()
+    {
+        return ReverbProperties(0.4287f, 1.0000f, 0.3162f, 0.1413f, 0.3981f, 0.7600f, 1.0000f, 1.0000f, 1.0000f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0120f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties PREFAB_SCHOOLROOM()
+    {
+        return ReverbProperties(0.4022f, 0.6900f, 0.3162f, 0.6310f, 0.5012f, 0.9800f, 0.4500f, 0.1800f, 1.4125f, 0.0170f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0150f, [0.0000f, 0.0000f, 0.0000f], 0.0950f, 0.1400f, 0.2500f, 0.0000f, 0.9943f, 7176.8999f, 211.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties PREFAB_PRACTISEROOM()
+    {
+        return ReverbProperties(0.4022f, 0.8700f, 0.3162f, 0.3981f, 0.5012f, 1.1200f, 0.5600f, 0.1800f, 1.2589f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0110f, [0.0000f, 0.0000f, 0.0000f], 0.0950f, 0.1400f, 0.2500f, 0.0000f, 0.9943f, 7176.8999f, 211.2000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties PREFAB_OUTHOUSE()
+    {
+        return ReverbProperties(1.0000f, 0.8200f, 0.3162f, 0.1122f, 0.1585f, 1.3800f, 0.3800f, 0.3500f, 0.8913f, 0.0240f, [0.0000f, 0.0000f, -0.0000f],
+        0.6310f, 0.0440f, [0.0000f, 0.0000f, 0.0000f], 0.1210f, 0.1700f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 107.5000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties PREFAB_CARAVAN()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.0891f, 0.1259f, 0.4300f, 1.5000f, 1.0000f, 1.0000f, 0.0120f, [0.0000f, 0.0000f, 0.0000f],
+        1.9953f, 0.0120f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+/* Dome and Pipe Presets */
+
+    static ReverbProperties DOME_TOMB()
+    {
+        return ReverbProperties(1.0000f, 0.7900f, 0.3162f, 0.3548f, 0.2239f, 4.1800f, 0.2100f, 0.1000f, 0.3868f, 0.0300f, [0.0000f, 0.0000f, 0.0000f],
+        1.6788f, 0.0220f, [0.0000f, 0.0000f, 0.0000f], 0.1770f, 0.1900f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 20.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties PIPE_SMALL()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.3548f, 0.2239f, 5.0400f, 0.1000f, 0.1000f, 0.5012f, 0.0320f, [0.0000f, 0.0000f, 0.0000f],
+        2.5119f, 0.0150f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 20.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties DOME_SAINTPAULS()
+    {
+        return ReverbProperties(1.0000f, 0.8700f, 0.3162f, 0.3548f, 0.2239f, 10.4800f, 0.1900f, 0.1000f, 0.1778f, 0.0900f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0420f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.1200f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 20.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties PIPE_LONGTHIN()
+    {
+        return ReverbProperties(0.2560f, 0.9100f, 0.3162f, 0.4467f, 0.2818f, 9.2100f, 0.1800f, 0.1000f, 0.7079f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        0.7079f, 0.0220f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 20.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties PIPE_LARGE()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.3548f, 0.2239f, 8.4500f, 0.1000f, 0.1000f, 0.3981f, 0.0460f, [0.0000f, 0.0000f, 0.0000f],
+        1.5849f, 0.0320f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 20.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties PIPE_RESONANT()
+    {
+        return ReverbProperties(0.1373f, 0.9100f, 0.3162f, 0.4467f, 0.2818f, 6.8100f, 0.1800f, 0.1000f, 0.7079f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.0000f, 0.0220f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 20.0000f, 0.0000f, 0x0 );
+
+    }
+
+/* Outdoors Presets */
+
+    static ReverbProperties OUTDOORS_BACKYARD()
+    {
+        return ReverbProperties(1.0000f, 0.4500f, 0.3162f, 0.2512f, 0.5012f, 1.1200f, 0.3400f, 0.4600f, 0.4467f, 0.0690f, [0.0000f, 0.0000f, -0.0000f],
+        0.7079f, 0.0230f, [0.0000f, 0.0000f, 0.0000f], 0.2180f, 0.3400f, 0.2500f, 0.0000f, 0.9943f, 4399.1001f, 242.9000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties OUTDOORS_ROLLINGPLAINS()
+    {
+        return ReverbProperties(1.0000f, 0.0000f, 0.3162f, 0.0112f, 0.6310f, 2.1300f, 0.2100f, 0.4600f, 0.1778f, 0.3000f, [0.0000f, 0.0000f, -0.0000f],
+        0.4467f, 0.0190f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 1.0000f, 0.2500f, 0.0000f, 0.9943f, 4399.1001f, 242.9000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties OUTDOORS_DEEPCANYON()
+    {
+        return ReverbProperties(1.0000f, 0.7400f, 0.3162f, 0.1778f, 0.6310f, 3.8900f, 0.2100f, 0.4600f, 0.3162f, 0.2230f, [0.0000f, 0.0000f, -0.0000f],
+        0.3548f, 0.0190f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 1.0000f, 0.2500f, 0.0000f, 0.9943f, 4399.1001f, 242.9000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties OUTDOORS_CREEK()
+    {
+        return ReverbProperties(1.0000f, 0.3500f, 0.3162f, 0.1778f, 0.5012f, 2.1300f, 0.2100f, 0.4600f, 0.3981f, 0.1150f, [0.0000f, 0.0000f, -0.0000f],
+        0.1995f, 0.0310f, [0.0000f, 0.0000f, 0.0000f], 0.2180f, 0.3400f, 0.2500f, 0.0000f, 0.9943f, 4399.1001f, 242.9000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties OUTDOORS_VALLEY()
+    {
+        return ReverbProperties(1.0000f, 0.2800f, 0.3162f, 0.0282f, 0.1585f, 2.8800f, 0.2600f, 0.3500f, 0.1413f, 0.2630f, [0.0000f, 0.0000f, -0.0000f],
+        0.3981f, 0.1000f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.3400f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 107.5000f, 0.0000f, 0x0 );
+
+    }
+
+/* Mood Presets */
+
+    static ReverbProperties MOOD_HEAVEN()
+    {
+        return ReverbProperties(1.0000f, 0.9400f, 0.3162f, 0.7943f, 0.4467f, 5.0400f, 1.1200f, 0.5600f, 0.2427f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0290f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0800f, 2.7420f, 0.0500f, 0.9977f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties MOOD_HELL()
+    {
+        return ReverbProperties(1.0000f, 0.5700f, 0.3162f, 0.3548f, 0.4467f, 3.5700f, 0.4900f, 2.0000f, 0.0000f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.1100f, 0.0400f, 2.1090f, 0.5200f, 0.9943f, 5000.0000f, 139.5000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties MOOD_MEMORY()
+    {
+        return ReverbProperties(1.0000f, 0.8500f, 0.3162f, 0.6310f, 0.3548f, 4.0600f, 0.8200f, 0.5600f, 0.0398f, 0.0000f, [0.0000f, 0.0000f, 0.0000f],
+        1.1220f, 0.0000f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.4740f, 0.4500f, 0.9886f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+/* Driving Presets */
+
+    static ReverbProperties DRIVING_COMMENTATOR()
+    {
+        return ReverbProperties(1.0000f, 0.0000f, 0.3162f, 0.5623f, 0.5012f, 2.4200f, 0.8800f, 0.6800f, 0.1995f, 0.0930f, [0.0000f, 0.0000f, 0.0000f],
+        0.2512f, 0.0170f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 1.0000f, 0.2500f, 0.0000f, 0.9886f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties DRIVING_PITGARAGE()
+    {
+        return ReverbProperties(0.4287f, 0.5900f, 0.3162f, 0.7079f, 0.5623f, 1.7200f, 0.9300f, 0.8700f, 0.5623f, 0.0000f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0160f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.1100f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties DRIVING_INCAR_RACER()
+    {
+        return ReverbProperties(0.0832f, 0.8000f, 0.3162f, 1.0000f, 0.7943f, 0.1700f, 2.0000f, 0.4100f, 1.7783f, 0.0070f, [0.0000f, 0.0000f, 0.0000f],
+        0.7079f, 0.0150f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 10268.2002f, 251.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties DRIVING_INCAR_SPORTS()
+    {
+        return ReverbProperties(0.0832f, 0.8000f, 0.3162f, 0.6310f, 1.0000f, 0.1700f, 0.7500f, 0.4100f, 1.0000f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        0.5623f, 0.0000f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 10268.2002f, 251.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties DRIVING_INCAR_LUXURY()
+    {
+        return ReverbProperties(0.2560f, 1.0000f, 0.3162f, 0.1000f, 0.5012f, 0.1300f, 0.4100f, 0.4600f, 0.7943f, 0.0100f, [0.0000f, 0.0000f, 0.0000f],
+        1.5849f, 0.0100f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 10268.2002f, 251.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties DRIVING_FULLGRANDSTAND()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 0.2818f, 0.6310f, 3.0100f, 1.3700f, 1.2800f, 0.3548f, 0.0900f, [0.0000f, 0.0000f, 0.0000f],
+        0.1778f, 0.0490f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 10420.2002f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties DRIVING_EMPTYGRANDSTAND()
+    {
+        return ReverbProperties(1.0000f, 1.0000f, 0.3162f, 1.0000f, 0.7943f, 4.6200f, 1.7500f, 1.4000f, 0.2082f, 0.0900f, [0.0000f, 0.0000f, 0.0000f],
+        0.2512f, 0.0490f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.0000f, 0.9943f, 10420.2002f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties DRIVING_TUNNEL()
+    {
+        return ReverbProperties(1.0000f, 0.8100f, 0.3162f, 0.3981f, 0.8913f, 3.4200f, 0.9400f, 1.3100f, 0.7079f, 0.0510f, [0.0000f, 0.0000f, 0.0000f],
+        0.7079f, 0.0470f, [0.0000f, 0.0000f, 0.0000f], 0.2140f, 0.0500f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 155.3000f, 0.0000f, 0x1 );
+
+    }
+
+/* City Presets */
+
+    static ReverbProperties CITY_STREETS()
+    {
+        return ReverbProperties(1.0000f, 0.7800f, 0.3162f, 0.7079f, 0.8913f, 1.7900f, 1.1200f, 0.9100f, 0.2818f, 0.0460f, [0.0000f, 0.0000f, 0.0000f],
+        0.1995f, 0.0280f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.2000f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CITY_SUBWAY()
+    {
+        return ReverbProperties(1.0000f, 0.7400f, 0.3162f, 0.7079f, 0.8913f, 3.0100f, 1.2300f, 0.9100f, 0.7079f, 0.0460f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0280f, [0.0000f, 0.0000f, 0.0000f], 0.1250f, 0.2100f, 0.2500f, 0.0000f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CITY_MUSEUM()
+    {
+        return ReverbProperties(1.0000f, 0.8200f, 0.3162f, 0.1778f, 0.1778f, 3.2800f, 1.4000f, 0.5700f, 0.2512f, 0.0390f, [0.0000f, 0.0000f, -0.0000f],
+        0.8913f, 0.0340f, [0.0000f, 0.0000f, 0.0000f], 0.1300f, 0.1700f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 107.5000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties CITY_LIBRARY()
+    {
+        return ReverbProperties(1.0000f, 0.8200f, 0.3162f, 0.2818f, 0.0891f, 2.7600f, 0.8900f, 0.4100f, 0.3548f, 0.0290f, [0.0000f, 0.0000f, -0.0000f],
+        0.8913f, 0.0200f, [0.0000f, 0.0000f, 0.0000f], 0.1300f, 0.1700f, 0.2500f, 0.0000f, 0.9943f, 2854.3999f, 107.5000f, 0.0000f, 0x0 );
+
+    }
+
+    static ReverbProperties CITY_UNDERPASS()
+    {
+        return ReverbProperties(1.0000f, 0.8200f, 0.3162f, 0.4467f, 0.8913f, 3.5700f, 1.1200f, 0.9100f, 0.3981f, 0.0590f, [0.0000f, 0.0000f, 0.0000f],
+        0.8913f, 0.0370f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.1400f, 0.2500f, 0.0000f, 0.9920f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CITY_ABANDONED()
+    {
+        return ReverbProperties(1.0000f, 0.6900f, 0.3162f, 0.7943f, 0.8913f, 3.2800f, 1.1700f, 0.9100f, 0.4467f, 0.0440f, [0.0000f, 0.0000f, 0.0000f],
+        0.2818f, 0.0240f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.2000f, 0.2500f, 0.0000f, 0.9966f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+/* Misc. Presets */
+
+    static ReverbProperties DUSTYROOM()
+    {
+        return ReverbProperties(0.3645f, 0.5600f, 0.3162f, 0.7943f, 0.7079f, 1.7900f, 0.3800f, 0.2100f, 0.5012f, 0.0020f, [0.0000f, 0.0000f, 0.0000f],
+        1.2589f, 0.0060f, [0.0000f, 0.0000f, 0.0000f], 0.2020f, 0.0500f, 0.2500f, 0.0000f, 0.9886f, 13046.0000f, 163.3000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties CHAPEL()
+    {
+        return ReverbProperties(1.0000f, 0.8400f, 0.3162f, 0.5623f, 1.0000f, 4.6200f, 0.6400f, 1.2300f, 0.4467f, 0.0320f, [0.0000f, 0.0000f, 0.0000f],
+        0.7943f, 0.0490f, [0.0000f, 0.0000f, 0.0000f], 0.2500f, 0.0000f, 0.2500f, 0.1100f, 0.9943f, 5000.0000f, 250.0000f, 0.0000f, 0x1 );
+
+    }
+
+    static ReverbProperties SMALLWATERROOM()
+    {
+        return ReverbProperties(1.0000f, 0.7000f, 0.3162f, 0.4477f, 1.0000f, 1.5100f, 1.2500f, 1.1400f, 0.8913f, 0.0200f, [0.0000f, 0.0000f, 0.0000f],
+        1.4125f, 0.0300f, [0.0000f, 0.0000f, 0.0000f], 0.1790f, 0.1500f, 0.8950f, 0.1900f, 0.9920f, 5000.0000f, 250.0000f, 0.0000f, 0x0 );
+
+    }
+}


### PR DESCRIPTION
Added too a new name for windows dll name, as it is the default name when compiling openal soft

Some test code adapted from the kcat repository that I used for testing the EAX/EFX extension using the reverb effect:

```d
ALuint loadReverb(ref ReverbProperties r)
{
    ALuint effect;

    alGenEffects(1, &effect);
    if(alGetEnumValue("AL_EFFECT_EAXREVERB") != 0)
    {
        /* EAX Reverb is available. Set the EAX effect type then load the
         * reverb properties. */
        alEffecti(effect, AL_EFFECT_TYPE, AL_EFFECT_EAXREVERB);

        ALfloat* reflecPan = &r.reflectionsPan[0];
        ALfloat* lateRevPan = &r.lateReverbPan[0];

        alEffectf(effect, AL_EAXREVERB_DENSITY, r.density);
        alEffectf(effect, AL_EAXREVERB_DIFFUSION, r.diffusion);
        alEffectf(effect, AL_EAXREVERB_GAIN, r.gain);
        alEffectf(effect, AL_EAXREVERB_GAINHF, r.gainHF);
        alEffectf(effect, AL_EAXREVERB_GAINLF, r.gainLF);
        alEffectf(effect, AL_EAXREVERB_DECAY_TIME, r.decayTime);
        alEffectf(effect, AL_EAXREVERB_DECAY_HFRATIO, r.decayHFRatio);
        alEffectf(effect, AL_EAXREVERB_DECAY_LFRATIO, r.decayLFRatio);
        alEffectf(effect, AL_EAXREVERB_REFLECTIONS_GAIN, r.reflectionsGain);
        alEffectf(effect, AL_EAXREVERB_REFLECTIONS_DELAY, r.reflectionsDelay);
        alEffectfv(effect,AL_EAXREVERB_REFLECTIONS_PAN, reflecPan);
        alEffectf(effect, AL_EAXREVERB_LATE_REVERB_GAIN, r.lateReverbGain);
        alEffectf(effect, AL_EAXREVERB_LATE_REVERB_DELAY, r.lateReverbDelay);
        alEffectfv(effect,AL_EAXREVERB_LATE_REVERB_PAN, lateRevPan);
        alEffectf(effect, AL_EAXREVERB_ECHO_TIME, r.echoTime);
        alEffectf(effect, AL_EAXREVERB_ECHO_DEPTH, r.echoDepth);
        alEffectf(effect, AL_EAXREVERB_MODULATION_TIME, r.modulationTime);
        alEffectf(effect, AL_EAXREVERB_MODULATION_DEPTH, r.modulationDepth);
        alEffectf(effect, AL_EAXREVERB_AIR_ABSORPTION_GAINHF, r.airAbsorptionGainHF);
        alEffectf(effect, AL_EAXREVERB_HFREFERENCE, r.HFReference);
        alEffectf(effect, AL_EAXREVERB_LFREFERENCE, r.LFReference);
        alEffectf(effect, AL_EAXREVERB_ROOM_ROLLOFF_FACTOR, r.roomRolloffFactor);
        alEffecti(effect, AL_EAXREVERB_DECAY_HFLIMIT, r.decayHFLimit);
    }
    else
    {
        usingEAXReverb = false;

        /* No EAX Reverb. Set the standard reverb effect type then load the
         * available reverb properties. */
        alEffecti(effect, AL_EFFECT_TYPE, AL_EFFECT_REVERB);

        alEffectf(effect, AL_REVERB_DENSITY, r.density);
        alEffectf(effect, AL_REVERB_DIFFUSION, r.diffusion);
        alEffectf(effect, AL_REVERB_GAIN, r.gain);
        alEffectf(effect, AL_REVERB_GAINHF, r.gainHF);
        alEffectf(effect, AL_REVERB_DECAY_TIME, r.decayTime);
        alEffectf(effect, AL_REVERB_DECAY_HFRATIO, r.decayHFRatio);
        alEffectf(effect, AL_REVERB_REFLECTIONS_GAIN, r.reflectionsGain);
        alEffectf(effect, AL_REVERB_REFLECTIONS_DELAY, r.reflectionsDelay);
        alEffectf(effect, AL_REVERB_LATE_REVERB_GAIN, r.lateReverbGain);
        alEffectf(effect, AL_REVERB_LATE_REVERB_DELAY, r.lateReverbDelay);
        alEffectf(effect, AL_REVERB_AIR_ABSORPTION_GAINHF, r.airAbsorptionGainHF);
        alEffectf(effect, AL_REVERB_ROOM_ROLLOFF_FACTOR, r.roomRolloffFactor);
        alEffecti(effect, AL_REVERB_DECAY_HFLIMIT, r.decayHFLimit);
    }

    /* Check if an error occured, and clean up if so. */
    int err = alGetError();
    if(err != AL_NO_ERROR)
    {
        if(alIsEffect(effect))
            alDeleteEffects(1, &effect);
        return 0;
    }

    return effect;
}
```